### PR TITLE
change: simplify external method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Rewrite the bopboard in OCaml using tsdl (it was in C and using SDL-1 which is now deprecated).
 - Rewrite visa assembly tool from C to OCaml.
 - Group executables into a single CLI named 'bopkit'.
+- In external blocks, always use method_name as implementation_name, merge the two concepts.
 
 ## Fixed
 

--- a/doc/reference/parameters.md
+++ b/doc/reference/parameters.md
@@ -74,8 +74,8 @@ a parameter.
 #define N 8
 
 external my_calculator "./my_calculator.exe -n %{N}"
-  def add ADD
-  def sub SUB
+  def add
+  def sub
   // ...
 end external;
 ```

--- a/lib/bopkit/src/expanded_netlist.ml
+++ b/lib/bopkit/src/expanded_netlist.ml
@@ -12,7 +12,6 @@ type memory =
 type external_method =
   { method_name : string
   ; attributes : string list
-  ; implementation_name : string
   }
 
 type external_block =

--- a/lib/bopkit/src/expanded_netlist.mli
+++ b/lib/bopkit/src/expanded_netlist.mli
@@ -17,7 +17,6 @@ type memory =
 type external_method =
   { method_name : string
   ; attributes : string list
-  ; implementation_name : string
   }
 
 type external_block =

--- a/lib/bopkit/src/netlist.ml
+++ b/lib/bopkit/src/netlist.ml
@@ -66,7 +66,6 @@ type external_block_api_element =
       ; method_name : string
       ; method_name_is_quoted : bool
       ; attributes : string list
-      ; implementation_name : string
       }
 [@@deriving equal, sexp_of]
 

--- a/lib/bopkit/src/netlist.mli
+++ b/lib/bopkit/src/netlist.mli
@@ -81,7 +81,6 @@ type external_block_api_element =
       ; method_name : string
       ; method_name_is_quoted : bool
       ; attributes : string list
-      ; implementation_name : string
       }
 [@@deriving equal, sexp_of]
 

--- a/lib/bopkit_compiler/src/pass_external_blocks.ml
+++ b/lib/bopkit_compiler/src/pass_external_blocks.ml
@@ -14,21 +14,14 @@ let pass (external_block : Bopkit.Netlist.external_block) ~error_log ~parameters
     match (element : Bopkit.Netlist.external_block_api_element) with
     | Init_message { loc; comments; message } ->
       Init_message { loc; comments; message = eval_string ~parameters message }
-    | Method
-        { loc
-        ; comments
-        ; method_name = a
-        ; method_name_is_quoted
-        ; attributes = att
-        ; implementation_name = b
-        } ->
+    | Method { loc; comments; method_name = a; method_name_is_quoted; attributes = att }
+      ->
       Method
         { loc
         ; comments
         ; method_name = (if method_name_is_quoted then eval_string ~parameters a else a)
         ; method_name_is_quoted
         ; attributes = att
-        ; implementation_name = eval_string ~parameters b
         }
   in
   let api =
@@ -38,17 +31,8 @@ let pass (external_block : Bopkit.Netlist.external_block) ~error_log ~parameters
   let init_messages = Queue.create () in
   let methods = Queue.create () in
   List.iter api ~f:(function
-    | Method
-        { loc = _
-        ; comments = _
-        ; method_name
-        ; method_name_is_quoted = _
-        ; attributes
-        ; implementation_name
-        } ->
-      Queue.enqueue
-        methods
-        { Bopkit.Expanded_netlist.method_name; attributes; implementation_name }
+    | Method { loc = _; comments = _; method_name; method_name_is_quoted = _; attributes }
+      -> Queue.enqueue methods { Bopkit.Expanded_netlist.method_name; attributes }
     | Init_message { loc = _; comments = _; message } ->
       Queue.enqueue init_messages message);
   { Bopkit.Expanded_netlist.loc = external_block.loc

--- a/lib/bopkit_pp/src/netlist.ml
+++ b/lib/bopkit_pp/src/netlist.ml
@@ -202,14 +202,7 @@ let pp_external_api ~first_in_group a =
       ; Pp.verbatim "init "
       ; Pp.verbatim (string_with_vars message)
       ]
-  | Method
-      { loc = _
-      ; comments
-      ; method_name
-      ; method_name_is_quoted
-      ; attributes
-      ; implementation_name
-      } ->
+  | Method { loc = _; comments; method_name; method_name_is_quoted; attributes } ->
     Pp.concat
       [ (if (not first_in_group) && not (Bopkit.Comments.is_empty comments)
          then Pp.newline
@@ -221,8 +214,6 @@ let pp_external_api ~first_in_group a =
          else pp_attributes attributes ++ Pp.verbatim " ")
       ; Pp.verbatim
           (if method_name_is_quoted then string_with_vars method_name else method_name)
-      ; Pp.verbatim " "
-      ; Pp.verbatim (string_with_vars implementation_name)
       ]
 ;;
 

--- a/lib/bopkit_simulator/src/circuit_simulator.ml
+++ b/lib/bopkit_simulator/src/circuit_simulator.ml
@@ -174,8 +174,7 @@ let init t =
              List.find decl_bloc.methods ~f:(fun m ->
                String.equal method_name m.method_name)
            with
-           | Some { method_name = _; attributes = _; implementation_name } ->
-             Some implementation_name
+           | Some { method_name; attributes = _ } -> Some method_name
            | None ->
              Error_log.warning
                t.error_log

--- a/lib/bopkit_syntax/src/external.mly
+++ b/lib/bopkit_syntax/src/external.mly
@@ -42,7 +42,7 @@ init_message_def_method:
       )
     }
 
-  | _d=DEF attributes=ident_list_option method_name=STRING implementation_name=STRING
+  | _d=DEF attributes=ident_list_option method_name=STRING
     { Bopkit.Control_structure.Node (
         Method
           { loc = Loc.create $loc
@@ -50,11 +50,10 @@ init_message_def_method:
           ; method_name
           ; method_name_is_quoted = true
           ; attributes
-          ; implementation_name
           })
     }
 
-  | _d=DEF attributes=ident_list_option method_name=IDENT implementation_name=STRING
+  | _d=DEF attributes=ident_list_option method_name=IDENT
     { Bopkit.Control_structure.Node (
         Method
           { loc = Loc.create $loc
@@ -62,7 +61,6 @@ init_message_def_method:
           ; method_name
           ; method_name_is_quoted = false
           ; attributes
-          ; implementation_name
           })
     }
 

--- a/stdlib/bopboard/README.md
+++ b/stdlib/bopboard/README.md
@@ -19,7 +19,7 @@ also designed the board's images as well as bopkit's ladybug.
 
 Using bopboard requires to install the bopkit package. The bopboard executable
 is installed via dune-sites in the bopkit's libexec directory, where the
-simulator knowns to find it.
+simulator knows to find it.
 
 ## Usage in bopkit file
 

--- a/stdlib/bopboard/bopboard.bop
+++ b/stdlib/bopboard/bopboard.bop
@@ -12,7 +12,7 @@ external bopboard "bopboard run"
    *
    * |    $bopboard.light("0", i);
    */
-  def light "LIGHT"
+  def light
 
   /**
    * Connect to the 8 switch buttons of the board.
@@ -24,7 +24,7 @@ external bopboard "bopboard run"
    *
    * |    p = $bopboard.switch("7");
    */
-  def switch "SWITCH"
+  def switch
 
   /**
    * Connect to the 5 push buttons of the board.
@@ -36,5 +36,5 @@ external bopboard "bopboard run"
    *
    * |    p = $bopboard.push("2");
    */
-  def push "PUSH"
+  def push
 end external;

--- a/stdlib/bopboard/example/README.md
+++ b/stdlib/bopboard/example/README.md
@@ -145,11 +145,11 @@ where
       addr:[N],
       write_mode,
       data_in:[N]);
-  addr:[N] = $board1.SWITCH();
-  write_mode = $board1.PUSH("0");
-  $board1.LIGHT(data_out:[N]);
-  data_in:[N] = $board2.SWITCH();
-  $board2.LIGHT(data_in:[N]);
+  addr:[N] = $board1.switch();
+  write_mode = $board1.push("0");
+  $board1.light(data_out:[N]);
+  data_in:[N] = $board2.switch();
+  $board2.light(data_in:[N]);
 end where;
 ```
 

--- a/stdlib/bopboard/example/ram.bop
+++ b/stdlib/bopboard/example/ram.bop
@@ -15,9 +15,9 @@ where
       addr:[N],
       write_mode,
       data_in:[N]);
-  addr:[N] = $board1.SWITCH();
-  write_mode = $board1.PUSH("0");
-  $board1.LIGHT(data_out:[N]);
-  data_in:[N] = $board2.SWITCH();
-  $board2.LIGHT(data_in:[N]);
+  addr:[N] = $board1.switch();
+  write_mode = $board1.push("0");
+  $board1.light(data_out:[N]);
+  data_in:[N] = $board2.switch();
+  $board2.light(data_in:[N]);
 end where;

--- a/stdlib/bopboard/src/bopboard.ml
+++ b/stdlib/bopboard/src/bopboard.ml
@@ -305,7 +305,7 @@ let light_method (t : t) =
      otherwise it should be empty in which case we set the entire light array.
      *)
   Bopkit_block.Method.create
-    ~name:"LIGHT"
+    ~name:"light"
     ~input_arity:Remaining_bits
     ~output_arity:Empty
     ~f:(fun ~arguments ~input ~output:() ->
@@ -399,8 +399,8 @@ let run_cmd =
        ~main:(main_method t)
        ~methods:
          [ light_method t
-         ; button_method t ~name:"PUSH" ~which_buttons:Board.pushes
-         ; button_method t ~name:"SWITCH" ~which_buttons:Board.switches
+         ; button_method t ~name:"push" ~which_buttons:Board.pushes
+         ; button_method t ~name:"switch" ~which_buttons:Board.switches
          ]
        ~is_multi_threaded:true
        ())

--- a/test/netlist/syntax/comments-above-for.bop
+++ b/test/netlist/syntax/comments-above-for.bop
@@ -4,7 +4,7 @@
 external with_loops "./with_loops.exe"
   // Such as this one!
   for i = 1 to 3
-    def "m%{i}" "IMPL_M%{i}"
+    def "m%{i}"
     // In the case of for loop, there might be tail comments.
   end for;
   // External blocks may have tail comments too.

--- a/test/netlist/syntax/comments-above-if.bop
+++ b/test/netlist/syntax/comments-above-if.bop
@@ -4,7 +4,7 @@
 external with_loops "./with_loops.exe"
   // Such as this one!
   if N mod 2 == 0 then
-    def "m%{i}" "IMPL_M%{i}"
+    def "m%{i}"
   end if;
 end external;
 

--- a/test/netlist/syntax/external-call.bop
+++ b/test/netlist/syntax/external-call.bop
@@ -4,12 +4,12 @@ external calc "./calc.exe -N %{N}"
   /**
    * Documentation for the add method.
    */
-  def add "ADD"
+  def add
 
   /**
    * Documentation for the mult method.
    */
-  def mult "MULT"
+  def mult
 end external;
 
 external pulse "./pulse.exe"

--- a/test/netlist/syntax/external.bop
+++ b/test/netlist/syntax/external.bop
@@ -5,16 +5,16 @@ external calc "./calc.exe -N %{N}"
 external [ Attr1, Attr2 ] with_attr "./with_attr.exe"
 
 external with_methods "%{PATH}/with_methods.exe -N %{N}"
-  def m1 "IMPL_M1"
-  def [ A1, A2 ] m2 "IMPL_M2"
-  def "m3" "IMPL_M3"
+  def m1
+  def [ A1, A2 ] m2
+  def "m3"
 end external;
 
 external with_loops "./with_loops.exe"
   for i = 1 to 3
     if i mod 2 == 0 then
       for j = i
-        def "m%{i}" "IMPL_M%{i}"
+        def "m%{i}"
       end for;
     end if;
   end for;

--- a/test/netlist/syntax/run.t
+++ b/test/netlist/syntax/run.t
@@ -27,7 +27,7 @@ monitor in tests.
   external with_loops "./with_loops.exe"
     // Such as this one!
     for i = 1 to 3
-      def "m%{i}" "IMPL_M%{i}"
+      def "m%{i}"
       // In the case of for loop, there might be tail comments.
     end for;
     // External blocks may have tail comments too.
@@ -48,7 +48,7 @@ monitor in tests.
   external with_loops "./with_loops.exe"
     // Such as this one!
     if N mod 2 == 0 then
-      def "m%{i}" "IMPL_M%{i}"
+      def "m%{i}"
     end if;
   end external;
   
@@ -140,12 +140,12 @@ monitor in tests.
     /**
      * Documentation for the add method.
      */
-    def add "ADD"
+    def add
   
     /**
      * Documentation for the mult method.
      */
-    def mult "MULT"
+    def mult
   end external;
   
   external pulse "./pulse.exe"
@@ -189,16 +189,16 @@ monitor in tests.
   external [ Attr1, Attr2 ] with_attr "./with_attr.exe"
   
   external with_methods "%{PATH}/with_methods.exe -N %{N}"
-    def m1 "IMPL_M1"
-    def [ A1, A2 ] m2 "IMPL_M2"
-    def "m3" "IMPL_M3"
+    def m1
+    def [ A1, A2 ] m2
+    def "m3"
   end external;
   
   external with_loops "./with_loops.exe"
     for i = 1 to 3
       if i mod 2 == 0 then
         for j = i
-          def "m%{i}" "IMPL_M%{i}"
+          def "m%{i}"
         end for;
       end if;
     end for;

--- a/tutorial/bdd/division/README.md
+++ b/tutorial/bdd/division/README.md
@@ -156,7 +156,7 @@ ROM div (8, 4) = file("div.txt")
 // An external block from which we'll use the [test] method for unit testing
 // the different means of computing the division.
 external div "./div.exe -N %{N}"
-  def test "test"
+  def test
 end external;
 
 Main(a:[N], b:[N]) = (s_reference:[4], s_rom:[4], s_bdd:[4], s_bdd_star:[4])

--- a/tutorial/bdd/division/div_check.bop
+++ b/tutorial/bdd/division/div_check.bop
@@ -9,7 +9,7 @@ ROM div (8, 4) = file("div.txt")
 // An external block from which we'll use the [test] method for unit testing
 // the different means of computing the division.
 external div "./div.exe -N %{N}"
-  def test "test"
+  def test
 end external;
 
 Main(a:[N], b:[N]) = (s_reference:[4], s_rom:[4], s_bdd:[4], s_bdd_star:[4])


### PR DESCRIPTION
Remove external implementation_name, make it so that it is always equal to method_name.

This simplifies the handling of external methods, which also makes it easier to explain and document.