### PR TITLE
Add implicit transitive deps

### DIFF
--- a/bopkit-tests.opam
+++ b/bopkit-tests.opam
@@ -33,7 +33,7 @@ depends: [
   "mdx" {>= "2.4"}
   "menhir" {>= "20220210"}
   "parsing-utils" {>= "0.2.2"}
-  "pp" {>= "1.2.0"}
+  "pp" {>= "2.0.0"}
   "pp-extended" {>= "0.0.2"}
   "pp-log" {>= "0.0.8"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}

--- a/bopkit.opam
+++ b/bopkit.opam
@@ -21,6 +21,7 @@ depends: [
   "cmdliner" {>= "1.3.0"}
   "comments-parser" {>= "0.2.2"}
   "core" {>= "v0.17" & < "v0.18"}
+  "core_kernel" {>= "v0.17" & < "v0.18"}
   "core_unix" {>= "v0.17" & < "v0.18"}
   "dune-site" {>= "3.16"}
   "fpath" {>= "0.7.3"}

--- a/bopkit.opam
+++ b/bopkit.opam
@@ -30,7 +30,7 @@ depends: [
   "mdx" {>= "2.4"}
   "menhir" {>= "20220210"}
   "parsing-utils" {>= "0.2.2"}
-  "pp" {>= "1.2.0"}
+  "pp" {>= "2.0.0"}
   "pp-extended" {>= "0.0.2"}
   "pp-log" {>= "0.0.8"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}

--- a/dune-project
+++ b/dune-project
@@ -61,6 +61,10 @@
    (and
     (>= v0.17)
     (< v0.18)))
+  (core_kernel
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (core_unix
    (and
     (>= v0.17)

--- a/dune-project
+++ b/dune-project
@@ -82,7 +82,7 @@
   (parsing-utils
    (>= 0.2.2))
   (pp
-   (>= 1.2.0))
+   (>= 2.0.0))
   (pp-extended
    (>= 0.0.2))
   (pp-log
@@ -189,7 +189,7 @@
   (parsing-utils
    (>= 0.2.2))
   (pp
-   (>= 1.2.0))
+   (>= 2.0.0))
   (pp-extended
    (>= 0.0.2))
   (pp-log
@@ -292,7 +292,7 @@
   (parsing-utils
    (>= 0.2.2))
   (pp
-   (>= 1.2.0))
+   (>= 2.0.0))
   (pp-extended
    (>= 0.0.2))
   (pp-log
@@ -405,7 +405,7 @@
   (parsing-utils
    (>= 0.2.2))
   (pp
-   (>= 1.2.0))
+   (>= 2.0.0))
   (pp-extended
    (>= 0.0.2))
   (pp-log

--- a/dune-project
+++ b/dune-project
@@ -21,8 +21,6 @@
 
 (using menhir 3.0)
 
-(cram enable)
-
 (package
  (name bopkit)
  (synopsis "An educational project for digital circuits programming")

--- a/lib/bopkit_block/src/dune
+++ b/lib/bopkit_block/src/dune
@@ -17,6 +17,7 @@
   -open
   Cmdlang)
  (libraries
+  base
   bit_utils
   cmdlang
   cmdlang-cmdliner-runner

--- a/lib/bopkit_circuit/src/dune
+++ b/lib/bopkit_circuit/src/dune
@@ -8,7 +8,9 @@
   bopkit
   bopkit_sites
   core ;; For [Core.Set_once]
+  fpath
   loc
+  pp
   pp-log.err)
  (lint
   (pps ppx_js_style -check-doc-comments))

--- a/lib/bopkit_command/src/dune
+++ b/lib/bopkit_command/src/dune
@@ -16,8 +16,11 @@
   -open
   Cmdlang)
  (libraries
+  auto-format
   base
+  bopkit
   bopkit_bdd_command
+  bopkit_circuit
   bopkit_compiler
   bopkit_counter
   bopkit_pp
@@ -32,6 +35,7 @@
   core
   fpath
   fpath-base
+  pp
   pp-log.cli
   pp-log.err
   seven_segment_display

--- a/lib/bopkit_compiler/src/dune
+++ b/lib/bopkit_compiler/src/dune
@@ -31,6 +31,7 @@
   graphics
   loc
   parsing-utils
+  pp
   pp-log.err
   unix)
  (lint

--- a/lib/bopkit_memory/src/dune
+++ b/lib/bopkit_memory/src/dune
@@ -11,7 +11,7 @@
   Base
   -open
   Stdio)
- (libraries base bit_utils graphics stdio)
+ (libraries base bit_utils fpath graphics stdio)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/lib/bopkit_pp/src/dune
+++ b/lib/bopkit_pp/src/dune
@@ -2,7 +2,7 @@
  (name bopkit_pp)
  (public_name bopkit.pp)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
- (libraries auto-format base bopkit bopkit_circuit pp)
+ (libraries auto-format base bopkit bopkit_circuit fpath pp)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/lib/bopkit_process_command/src/dune
+++ b/lib/bopkit_process_command/src/dune
@@ -23,6 +23,7 @@
   cmdlang
   fpath
   fpath-base
+  parsing-utils
   pp
   pp-log.cli
   pp-log.err)

--- a/lib/bopkit_process_interpreter/src/dune
+++ b/lib/bopkit_process_interpreter/src/dune
@@ -17,6 +17,7 @@
   bopkit_process
   bopkit_process_syntax
   loc
+  pp
   pp-log.err
   stdio)
  (lint

--- a/lib/bopkit_simulator/src/dune
+++ b/lib/bopkit_simulator/src/dune
@@ -15,13 +15,17 @@
   Cmdlang)
  (libraries
   base
+  bit_utils
+  bopkit
   bopkit_circuit
+  bopkit_sites
   cmdlang
   core
   core_unix
   core_unix.sys_unix
   fpath
   loc
+  pp
   pp-log.err
   stdio)
  (lint

--- a/lib/bopkit_sleeper/src/dune
+++ b/lib/bopkit_sleeper/src/dune
@@ -2,7 +2,7 @@
  (name bopkit_sleeper)
  (public_name bopkit.sleeper)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Core)
- (libraries core core_unix)
+ (libraries core core_kernel.caml_unix core_unix)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/lib/bopkit_syntax/src/dune
+++ b/lib/bopkit_syntax/src/dune
@@ -16,4 +16,4 @@
  (name bopkit_syntax)
  (public_name bopkit.syntax)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Core)
- (libraries bopkit comments-parser core loc parsing-utils))
+ (libraries bopkit comments-parser core fpath loc parsing-utils))

--- a/lib/bopkit_to_c/src/dune
+++ b/lib/bopkit_to_c/src/dune
@@ -4,8 +4,10 @@
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
  (libraries
   base
+  bit_utils
   bopkit_circuit
   bopkit_compiler
+  fpath
   loc
   parsing-utils
   pp

--- a/lib/bopkit_topological_sort/test/dune
+++ b/lib/bopkit_topological_sort/test/dune
@@ -12,6 +12,7 @@
   -open
   Expect_test_helpers_base)
  (libraries
+  appendable-list
   base
   bopkit_topological_sort
   expect_test_helpers_core.expect_test_helpers_base

--- a/project/subleq/circuit/dune
+++ b/project/subleq/circuit/dune
@@ -13,13 +13,16 @@
   Cmdlang)
  (libraries
   base
+  bit_utils
   cmdlang
   core
   core_unix.core_thread
   bopkit_block
   bopkit_sleeper
+  fpath
   graphics
   bopkit_memory
+  stdio
   unix
   threads)
  (preprocess

--- a/project/visa/circuit/dune
+++ b/project/visa/circuit/dune
@@ -174,6 +174,7 @@
   Cmdlang)
  (libraries
   base
+  bit_utils
   bopkit_block
   cmdlang
   cmdlang-cmdliner-runner

--- a/project/visa/lib/visa_assembler/src/dune
+++ b/project/visa/lib/visa_assembler/src/dune
@@ -2,7 +2,7 @@
  (name visa_assembler)
  (public_name bopkit.visa-assembler)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Base)
- (libraries base loc pp-log.err visa)
+ (libraries base loc pp pp-log.err visa)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/project/visa/lib/visa_command/src/dune
+++ b/project/visa/lib/visa_command/src/dune
@@ -22,6 +22,8 @@
   core
   fpath
   fpath-base
+  parsing-utils
+  pp-extended
   pp-log.cli
   pp-log.err
   seven_segment_display

--- a/project/visa/lib/visa_dsl/test/dune
+++ b/project/visa/lib/visa_dsl/test/dune
@@ -19,6 +19,7 @@
   pp-extended
   pp-log.err
   visa
+  visa_assembler
   visa_dsl
   visa_pp
   visa_simulator)

--- a/project/visa/lib/visa_simulator/src/dune
+++ b/project/visa/lib/visa_simulator/src/dune
@@ -26,6 +26,8 @@
   fpath
   fpath-base
   loc
+  parsing-utils
+  pp
   pp-log.cli
   pp-log.err
   stdio

--- a/stdlib/7-segment/src/dune
+++ b/stdlib/7-segment/src/dune
@@ -19,6 +19,8 @@
   bit_utils
   cmdlang
   core
+  core_kernel.caml_threads
+  core_kernel.caml_unix
   core_unix
   core_unix.core_thread
   graphics

--- a/stdlib/7-segment/test/dune
+++ b/stdlib/7-segment/test/dune
@@ -10,7 +10,11 @@
   Core
   -open
   Seven_segment_display)
- (libraries bopkit.seven-segment-display core expect_test_helpers_core)
+ (libraries
+  bit_utils
+  bopkit.seven-segment-display
+  core
+  expect_test_helpers_core)
  (inline_tests)
  (lint
   (pps ppx_js_style -check-doc-comments))

--- a/stdlib/bopboard/src/dune
+++ b/stdlib/bopboard/src/dune
@@ -22,6 +22,7 @@
   core_unix.core_thread
   core_unix.sys_unix
   graphics
+  stdio
   threads
   tsdl
   tsdl-image)

--- a/stdlib/counter/src/dune
+++ b/stdlib/counter/src/dune
@@ -13,7 +13,17 @@
   Stdio
   -open
   Cmdlang)
- (libraries bopkit_block bopkit_sleeper core graphics threads unix)
+ (libraries
+  base
+  bit_utils
+  bopkit_block
+  bopkit_sleeper
+  cmdlang
+  core
+  graphics
+  stdio
+  threads
+  unix)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/stdlib/memories/bin/dune
+++ b/stdlib/memories/bin/dune
@@ -13,6 +13,7 @@
   Cmdlang)
  (libraries
   base
+  bit_utils
   cmdlang
   core
   core_unix.core_thread
@@ -21,6 +22,7 @@
   bopkit_sleeper
   graphics
   unix
+  stdio
   threads)
  (preprocess
   (pps

--- a/stdlib/pulse/bin/dune
+++ b/stdlib/pulse/bin/dune
@@ -1,6 +1,6 @@
 (executables
  (names pulse)
- (libraries bopkit_pulse cmdliner cmdlang-to-cmdliner))
+ (libraries bopkit_pulse cmdlang-cmdliner-runner))
 
 (install
  (package bopkit)

--- a/stdlib/pulse/src/dune
+++ b/stdlib/pulse/src/dune
@@ -13,7 +13,7 @@
   Stdio
   -open
   Cmdlang)
- (libraries base bopkit_block bopkit_sleeper cmdlang core unix)
+ (libraries base bopkit_block bopkit_sleeper cmdlang core stdio unix)
  (lint
   (pps ppx_js_style -check-doc-comments))
  (preprocess

--- a/subleq.opam
+++ b/subleq.opam
@@ -30,7 +30,7 @@ depends: [
   "mdx" {>= "2.4"}
   "menhir" {>= "20220210"}
   "parsing-utils" {>= "0.2.2"}
-  "pp" {>= "1.2.0"}
+  "pp" {>= "2.0.0"}
   "pp-extended" {>= "0.0.2"}
   "pp-log" {>= "0.0.8"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}

--- a/tutorial/bdd/division/dune
+++ b/tutorial/bdd/division/dune
@@ -34,7 +34,16 @@
   Stdio
   -open
   Cmdlang)
- (libraries base cmdlang bopkit_block core graphics stdio unix threads)
+ (libraries
+  base
+  bit_utils
+  cmdlang
+  bopkit_block
+  core
+  graphics
+  stdio
+  unix
+  threads)
  (preprocess
   (pps
    ppx_compare

--- a/visa.opam
+++ b/visa.opam
@@ -30,7 +30,7 @@ depends: [
   "mdx" {>= "2.4"}
   "menhir" {>= "20220210"}
   "parsing-utils" {>= "0.2.2"}
-  "pp" {>= "1.2.0"}
+  "pp" {>= "2.0.0"}
   "pp-extended" {>= "0.0.2"}
   "pp-log" {>= "0.0.8"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
Add missing dependencies, in preparation for enabling `(implicit_transitive_deps false)` with `dune.3.17`.