### PR TITLE
Format dune file

### DIFF
--- a/doc/reference/dune
+++ b/doc/reference/dune
@@ -7,17 +7,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-dev)

--- a/project/digital-watch/dune
+++ b/project/digital-watch/dune
@@ -88,17 +88,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/project/subleq/circuit/dune
+++ b/project/subleq/circuit/dune
@@ -63,14 +63,16 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))

--- a/project/visa/circuit/dune
+++ b/project/visa/circuit/dune
@@ -3,38 +3,42 @@
 (include dune.bop.inc)
 
 (rule
- (target dune.asm.inc)
+ (target dune.asm.inc.raw)
  (deps
   (glob_files *.asm))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file))))
 
 (rule
- (target dune.bop.inc)
- (deps
-  (glob_files *.bop))
  (alias runtest)
  (mode promote)
  (action
+  (format-dune-file dune.asm.inc.raw dune.asm.inc)))
+
+(rule
+ (target dune.bop.inc.raw)
+ (deps
+  (glob_files *.bop))
+ (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run
-     %{bin:bopkit}
-     fmt
-     gen-dune
-     --exclude
-     div10.bop
-     "\%{bin:bopkit}"
-     fmt
-     file)
-    (run dune format-dune-file)))))
+   (run
+    %{bin:bopkit}
+    fmt
+    gen-dune
+    --exclude
+    div10.bop
+    "\%{bin:bopkit}"
+    fmt
+    file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.bop.inc.raw dune.bop.inc)))
 
 (rule
  (with-stdout-to

--- a/project/visa/test/assembler/error/dune
+++ b/project/visa/test/assembler/error/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.asm))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/project/visa/test/runtime/dune
+++ b/project/visa/test/runtime/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.asm))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:visa} fmt gen-dune "\%{bin:visa}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (rule
  (copy ../../circuit/visa.bop visa.bop))

--- a/stdlib/7-segment/dune
+++ b/stdlib/7-segment/dune
@@ -8,17 +8,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/stdlib/bopboard/dune
+++ b/stdlib/bopboard/dune
@@ -8,14 +8,16 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))

--- a/stdlib/bopboard/example/dune
+++ b/stdlib/bopboard/example/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/stdlib/counter/dune
+++ b/stdlib/counter/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (mdx
  (package bopkit-dev)

--- a/stdlib/counter/test/dune
+++ b/stdlib/counter/test/dune
@@ -7,14 +7,16 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))

--- a/stdlib/pulse/dune
+++ b/stdlib/pulse/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (install
  (package bopkit)

--- a/stdlib/pulse/test/dune
+++ b/stdlib/pulse/test/dune
@@ -7,14 +7,16 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))

--- a/stdlib/stdlib/dune
+++ b/stdlib/stdlib/dune
@@ -8,17 +8,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/stdlib/stdlib/test/dune
+++ b/stdlib/stdlib/test/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/bop2c/dune
+++ b/test/bop2c/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (rule
  (copy gen-dune/main.exe gen-dune.exe))
@@ -19,17 +21,19 @@
 (include dune-bop2c.inc)
 
 (rule
- (target dune-bop2c.inc)
+ (target dune-bop2c.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{dep:gen-dune.exe})
-    (run dune format-dune-file)))))
+   (run %{dep:gen-dune.exe}))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune-bop2c.inc.raw dune-bop2c.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/netlist/check/dune
+++ b/test/netlist/check/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/netlist/error/dune
+++ b/test/netlist/error/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/netlist/runtime/dune
+++ b/test/netlist/runtime/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/process/error/dune
+++ b/test/process/error/dune
@@ -1,25 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bpp))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run
-     %{bin:bopkit}
-     process
-     fmt
-     gen-dune
-     "\%{bin:bopkit}"
-     process
-     fmt
-     file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} process fmt gen-dune "\%{bin:bopkit}" process fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/test/process/runtime/dune
+++ b/test/process/runtime/dune
@@ -1,25 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bpp))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run
-     %{bin:bopkit}
-     process
-     fmt
-     gen-dune
-     "\%{bin:bopkit}"
-     process
-     fmt
-     file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} process fmt gen-dune "\%{bin:bopkit}" process fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/tutorial/bdd/division/dune
+++ b/tutorial/bdd/division/dune
@@ -1,25 +1,27 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run
-     %{bin:bopkit}
-     fmt
-     gen-dune
-     --exclude
-     div.bop,div_opt.bop
-     "\%{bin:bopkit}"
-     fmt
-     file)
-    (run dune format-dune-file)))))
+   (run
+    %{bin:bopkit}
+    fmt
+    gen-dune
+    --exclude
+    div.bop,div_opt.bop
+    "\%{bin:bopkit}"
+    fmt
+    file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (executables
  (names div div_opt)

--- a/tutorial/functional-args/dune
+++ b/tutorial/functional-args/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/tutorial/hello-world/dune
+++ b/tutorial/hello-world/dune
@@ -7,17 +7,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (mdx
  (package bopkit-dev)

--- a/tutorial/misc/dune
+++ b/tutorial/misc/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)

--- a/tutorial/parametrized-blocks/dune
+++ b/tutorial/parametrized-blocks/dune
@@ -1,17 +1,19 @@
 (include dune.inc)
 
 (rule
- (target dune.inc)
+ (target dune.inc.raw)
  (deps
   (glob_files *.bop))
- (alias runtest)
- (mode promote)
  (action
   (with-stdout-to
    %{target}
-   (pipe-stdout
-    (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file)
-    (run dune format-dune-file)))))
+   (run %{bin:bopkit} fmt gen-dune "\%{bin:bopkit}" fmt file))))
+
+(rule
+ (alias runtest)
+ (mode promote)
+ (action
+  (format-dune-file dune.inc.raw dune.inc)))
 
 (cram
  (package bopkit-tests)


### PR DESCRIPTION
Migration from calls to `dune format-dune-file` in action to the new `(format-dune-file)` stanza of `dune.3.18`.